### PR TITLE
chore(cli): polish output for routes

### DIFF
--- a/fastapi_checks/cli/commands/routes.py
+++ b/fastapi_checks/cli/commands/routes.py
@@ -51,7 +51,7 @@ def list_routes(
         return ", ".join(list(r.route.methods))
 
     def row_description(r):
-        return f"{r.route.description or r.route.name} - {r.operation_id}"
+        return f"{r.route.description or r.route.name}"
 
     def row_dependencies(r):
         dep_names = [dep.humanized for dep in r.unique_dependencies]

--- a/fastapi_checks/models/table.py
+++ b/fastapi_checks/models/table.py
@@ -82,6 +82,7 @@ class Table(BaseModel):
                 # wrap cells contents
                 "whiteSpace": "normal",
                 "height": "auto",
+                "wordBreak": "break-word",
             },
             style_data_conditional=[col.html_style_data() for col in self.columns],
             style_header={

--- a/tests/cli/__snapshots__/test_command_routes.ambr
+++ b/tests/cli/__snapshots__/test_command_routes.ambr
@@ -6,18 +6,18 @@
     Route       │ Method │ Description │ Dependenci… │ marks       │ Security     
   ╶─────────────┼────────┼─────────────┼─────────────┼─────────────┼─────────────╴
     /resource/… │ GET    │ Get         │ RouterDep   │ misc        │              
-                │        │ resource -  │ Config      │             │              
-                │        │ Get_resour… │ some_depen… │             │              
+                │        │ resource    │ Config      │             │              
+                │        │             │ some_depen… │             │              
                 │        │             │ ClassDep    │             │              
                 │        │             │ ClassDep    │             │              
     /resource/… │ GET    │ Get         │ RouterDep   │ misc        │ myapp:some…  
-                │        │ resource -  │ Config      │             │              
-                │        │ Get_resour… │ ClassDep    │             │              
+                │        │ resource    │ Config      │             │              
+                │        │             │ ClassDep    │             │              
                 │        │             │ some_depen… │             │              
                 │        │             │ ClassDep    │             │              
     /resource/… │ DELETE │ Delete      │ RouterDep   │ tenant_enf… │              
-                │        │ resource -  │ Config      │             │              
-                │        │ Delete_res… │ with_tenan… │             │              
+                │        │ resource    │ Config      │             │              
+                │        │             │ with_tenan… │             │              
                 │        │             │ ClassDep    │             │              
                 ╵        ╵             ╵             ╵             ╵              
   


### PR DESCRIPTION
## Description

Make small adjustments to the output of the `routes` command:
- add `word-break` rule to keep columns from taking too much space
- remove the route's `operation_id` from the description column