### PR TITLE
ci: fix syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - id: checkout
         uses: actions/checkout@v4
-        ref: master
         with:
           fetch-depth: 0
+          ref: master
       - id: setup-python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
### Description

Fix bad indentation for `ref` arg in `release.yml`, to fix fatal error in CI run ([example](https://github.com/alixlahuec/fastapi-checks/actions/runs/7349834983)).