### PR TITLE
ci: use exact version for python-semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.10.4'
 
       - id: semantic-release
-        uses: python-semantic-release/python-semantic-release@v8
+        uses: python-semantic-release/python-semantic-release@v8.7.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           root_options: "-vv"


### PR DESCRIPTION
### Description

Specify the exact version of `python-semantic-release` to use, as using only the major version [doesn't work](https://github.com/alixlahuec/fastapi-checks/actions/runs/7349880960/job/20010561938).