### PR TITLE
ci: add changelog template

### DIFF
--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,0 +1,14 @@
+# CHANGELOG
+{% if context.history.unreleased | length > 0 %}## Unreleased
+{% for type_, commits in context.history.unreleased | dictsort %}
+### {{ type_ | capitalize }}
+{% for commit in commits %}{% if type_ != "unknown" %}
+* {{ commit.message.rstrip() }} ([`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }}))
+{% else %}
+* {{ commit.message.rstrip() }} ([`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }}))
+{% endif %}{% endfor %}{% endfor %}{% endif %}
+{% for version, release in context.history.released.items() %}
+## {{ version.as_semver_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+{% for type_, commits in release["elements"] | dictsort %}{% if type_ != "unknown" %}{% for commit in commits %}
+* {{ commit.message.rstrip() }} ([`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }}))
+{% endfor %}{% endif %}{% endfor %}{% endfor %}


### PR DESCRIPTION
### Description

Add a custom changelog template, adapted from [the built-in template](https://github.com/python-semantic-release/python-semantic-release/blob/0b07cae71915c5c82d7784898b44359249542a64/semantic_release/data/templates/CHANGELOG.md.j2):
- all commits for a release are rendered together (no more subheaders by type)
- commits with "unknown" type aren't rendered
- small spacing adjustments are made