### PR TITLE
ci: add missing interpolation for release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
           generateReleaseNotes: true
           makeLatest: true
           name: "v${{ steps.semantic-release.outputs.tag }}"
-          tag: steps.semantic-release.outputs.tag
+          tag: ${{ steps.semantic-release.outputs.tag }}
           token: ${{ secrets.GH_RELEASE_TOKEN }}  # needed for the publish workflow to be triggered
 
       - id: workflow-summary


### PR DESCRIPTION
### Description

Fix missing `${{ ... }}` around the `tag` used for GitHub releases, to avoid double-tagging and ensure the release is linked to the correct tag.